### PR TITLE
Feat/flatten

### DIFF
--- a/.claude/specs/processing/tasks.md
+++ b/.claude/specs/processing/tasks.md
@@ -37,11 +37,11 @@ Each task:
 
 ### Phase 1: Core Infrastructure
 
-- [ ] 1.0 Implement flattening utilities with tests
+- [x] 1.0 Implement flattening utilities with tests
   - Purpose: Create and test PyTree flattening to unified token arrays
   - _Requirements: 2.1, 2.2_
 
-  - [ ] 1.1 Create flattening utility tests in test/test_preprocessing/test_flatten.py
+  - [x] 1.1 Create flattening utility tests in test/test_preprocessing/test_flatten.py
     - File: test/test_preprocessing/test_flatten.py
     - Test `flatten_pytree()` with simple PyTree (2-3 keys)
     - Test padding with different batch dimensions
@@ -51,7 +51,7 @@ Each task:
     - _Leverage: sfmpe_legacy/examples/hierarchical_gaussian.py (lines 48-52)_
     - _Requirements: 2.1, 2.2_
 
-  - [ ] 1.2 Create flattening utilities in tfmpe/preprocessing/flatten.py
+  - [x] 1.2 Create flattening utilities in tfmpe/preprocessing/flatten.py
     - File: tfmpe/preprocessing/flatten.py
     - Port `flatten_blocks()` from legacy, rename to `flatten_pytree()`
     - Single unified flattening (not separate theta/y)
@@ -62,11 +62,11 @@ Each task:
     - _Leverage: sfmpe_legacy/sfmpe/util/dataloader.py (lines 140-223)_
     - _Requirements: 2.1, 2.2_
 
-- [ ] 2.0 Implement reconstruction utilities with tests
+- [x] 2.0 Implement reconstruction utilities with tests
   - Purpose: Create and test PyTree reconstruction from flat arrays
   - _Requirements: 2.2, 2.5_
 
-  - [ ] 2.1 Create reconstruction tests in test/test_preprocessing/test_reconstruct.py
+  - [x] 2.1 Create reconstruction tests in test/test_preprocessing/test_reconstruct.py
     - File: test/test_preprocessing/test_reconstruct.py
     - Test full PyTree reconstruction
     - Test selective key reconstruction with `decode_pytree_keys()`
@@ -76,7 +76,7 @@ Each task:
     - _Leverage: test/conftest.py for fixtures_
     - _Requirements: 2.2, 2.5_
 
-  - [ ] 2.2 Create reconstruction utilities in tfmpe/preprocessing/reconstruct.py
+  - [x] 2.2 Create reconstruction utilities in tfmpe/preprocessing/reconstruct.py
     - File: tfmpe/preprocessing/reconstruct.py
     - Port `decode_theta()` from legacy, rename to `decode_pytree()`
     - Add `decode_pytree_keys()` for selective key reconstruction
@@ -112,11 +112,11 @@ Each task:
     - _Leverage: sfmpe_legacy/sfmpe/util/dataloader.py (lines 225-432)_
     - _Requirements: 3.1-3.5, 4.1-4.3_
 
-- [ ] 4.0 Implement functional input utilities with tests
+- [x] 4.0 Implement functional input utilities with tests
   - Purpose: Create and test functional input flattening
   - _Requirements: 3.1-3.4_
 
-  - [ ] 4.1 Create functional input tests in test/test_preprocessing/test_functional_inputs.py
+  - [x] 4.1 Create functional input tests in test/test_preprocessing/test_functional_inputs.py
     - File: test/test_preprocessing/test_functional_inputs.py
     - Test flattening with matching shapes
     - Test padding with sentinel value (-1e8)
@@ -126,7 +126,7 @@ Each task:
     - _Leverage: sfmpe_legacy/examples/hierarchical_brownian.py (lines 104-112)_
     - _Requirements: 3.1-3.4_
 
-  - [ ] 4.2 Create functional input utilities in tfmpe/preprocessing/functional_inputs.py
+  - [x] 4.2 Create functional input utilities in tfmpe/preprocessing/functional_inputs.py
     - File: tfmpe/preprocessing/functional_inputs.py
     - Port `_flatten_index()` from legacy, rename to `flatten_functional_inputs()`
     - Adapt to work with unified slices dict (not separate theta/y)

--- a/test/test_preprocessing/test_flatten.py
+++ b/test/test_preprocessing/test_flatten.py
@@ -1,0 +1,271 @@
+"""Tests for PyTree flattening utilities.
+
+Tests verify flattening of hierarchical parameter structures into flat
+arrays, with padding, slice tracking, and value override capabilities.
+"""
+
+import jax.numpy as jnp
+import pytest
+from jaxtyping import Array
+
+from tfmpe.preprocessing import flatten_pytree, update_flat_array
+
+
+def test_flatten_pytree_simple():
+    """Test flatten_pytree with simple 2-key PyTree."""
+    # Simple PyTree with 2 parameters
+    # Convention: (*event, *batch)
+    pytree = {
+        'mu': jnp.array([[1.0], [2.0]]),  # shape: (2, 1) - 2 events, 1 batch
+        'sigma': jnp.array([[0.5]])  # shape: (1, 1) - 1 event, 1 batch
+    }
+
+    flat_array, slices_dict = flatten_pytree(
+        pytree, sample_ndims=0, batch_ndims={'mu': 1, 'sigma': 1}
+    )
+
+    # Check flat array shape: (2+1, 1) = (3, 1)
+    assert flat_array.shape == (3, 1)
+    # Check concatenation: [1.0, 2.0, 0.5]
+    assert jnp.allclose(flat_array[:, 0], jnp.array([1.0, 2.0, 0.5]))
+
+    # Check slices metadata
+    assert 'mu' in slices_dict
+    assert 'sigma' in slices_dict
+    assert slices_dict['mu']['offset'] == 0
+    assert slices_dict['sigma']['offset'] == 2
+    assert slices_dict['mu']['event_shape'] == (2,)
+    assert slices_dict['sigma']['event_shape'] == (1,)
+
+
+@pytest.mark.parametrize(
+    "batch_dims,expected_batch_size",
+    [
+        ({'mu': 1, 'sigma': 1}, 3),  # max(3, 1) = 3
+        ({'mu': 1, 'sigma': 1}, 5),  # max(5, 1) = 5
+    ]
+)
+def test_flatten_pytree_padding(batch_dims, expected_batch_size):
+    """Test padding with different batch dimensions."""
+    # Convention: (*event, *batch)
+    # PyTree with different batch sizes
+    pytree = {
+        'mu': jnp.ones((2, expected_batch_size)),  # 2 events, batch size
+        'sigma': jnp.ones((1, 1))  # 1 event, batch size 1
+    }
+
+    flat_array, slices_dict = flatten_pytree(
+        pytree,
+        sample_ndims=0,
+        batch_ndims=batch_dims,
+        pad_value=-999.0
+    )
+
+    # Check shape: (2+1 events, max_batch)
+    assert flat_array.shape == (3, expected_batch_size)
+
+    # Check padding applied to sigma
+    # sigma should be padded from batch_size=1 to expected_batch_size
+    sigma_offset = slices_dict['sigma']['offset']
+    sigma_data = flat_array[sigma_offset, :]
+
+    # First element should be valid (1.0)
+    assert jnp.allclose(sigma_data[:1], jnp.ones(1))
+    # Remaining should be padding (-999.0)
+    if expected_batch_size > 1:
+        assert jnp.allclose(
+            sigma_data[1:],
+            jnp.full(expected_batch_size - 1, -999.0)
+        )
+
+
+@pytest.mark.parametrize(
+    "structure",
+    [
+        {
+            'mu': jnp.array([[1.0]]),  # (1 event, 1 batch)
+            'theta': jnp.array([[2.0], [3.0]]),  # (2 events, 1 batch)
+            'obs': jnp.array([[4.0]])  # (1 event, 1 batch)
+        },
+        {
+            'hyperprior': jnp.array([[1.0]]),  # (1, 1)
+            'prior_params': jnp.array([[2.0], [3.0]]),  # (2, 1)
+            'theta': jnp.array([[4.0], [5.0]]),  # (2, 1)
+            'obs': jnp.array([[6.0], [7.0], [8.0]])  # (3, 1)
+        },
+    ]
+)
+def test_flatten_reconstruct_roundtrip(structure):
+    """Test round-trip: flatten → reconstruct using slices."""
+    batch_ndims = {key: 1 for key in structure.keys()}
+
+    # Flatten
+    flat_array, slices_dict = flatten_pytree(
+        structure, sample_ndims=0, batch_ndims=batch_ndims
+    )
+
+    # Reconstruct using slices
+    reconstructed = {}
+    for key, slice_info in slices_dict.items():
+        offset = slice_info['offset']
+        event_shape = slice_info['event_shape']
+        batch_shape = slice_info['batch_shape']
+
+        # Calculate end offset
+        event_size = int(jnp.prod(jnp.array(event_shape)))
+        end_offset = offset + event_size
+
+        # Extract slice and reshape
+        slice_data = flat_array[offset:end_offset, :batch_shape[0]]
+        reconstructed[key] = slice_data.reshape(
+            event_shape + (batch_shape[0],)
+        )
+
+    # Verify round-trip
+    for key in structure.keys():
+        assert jnp.allclose(reconstructed[key], structure[key])
+
+
+def test_update_flat_array():
+    """Test update_flat_array updates correct offsets."""
+    # Hardcoded flat array: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    # Representing: a=[1.0, 2.0], b=[3.0], c=[4.0, 5.0, 6.0]
+    flat_array = jnp.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]).T
+
+    slices_dict = {
+        'a': {
+            'offset': 0,
+            'event_shape': (2,),
+            'batch_shape': (1,)
+        },
+        'b': {
+            'offset': 2,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        },
+        'c': {
+            'offset': 3,
+            'event_shape': (3,),
+            'batch_shape': (1,)
+        }
+    }
+
+    # Update 'b' with new values
+    new_b_values = jnp.array([[99.0]])  # (1, 1)
+    updated_array = update_flat_array(
+        flat_array, slices_dict, 'b', new_b_values
+    )
+
+    # Check that only 'b' was updated
+    assert jnp.allclose(updated_array[0:2, 0], jnp.array([1.0, 2.0]))  # a
+    assert jnp.allclose(updated_array[2, 0], 99.0)  # b (updated)
+    assert jnp.allclose(
+        updated_array[3:6, 0], jnp.array([4.0, 5.0, 6.0])
+    )  # c
+
+    # Verify original array unchanged
+    assert jnp.allclose(flat_array[2, 0], 3.0)
+
+
+def test_update_flat_array_multiple_keys():
+    """Test updating multiple keys in sequence."""
+    # Hardcoded flat array: [1.0, 2.0, 3.0]
+    # Representing: x=[1.0], y=[2.0, 3.0]
+    flat_array = jnp.array([[1.0, 2.0, 3.0]]).T
+
+    slices_dict = {
+        'x': {
+            'offset': 0,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        },
+        'y': {
+            'offset': 1,
+            'event_shape': (2,),
+            'batch_shape': (1,)
+        }
+    }
+
+    # Update both keys
+    updated = update_flat_array(
+        flat_array, slices_dict, 'x', jnp.array([[10.0]])
+    )
+    updated = update_flat_array(
+        updated, slices_dict, 'y', jnp.array([[20.0, 30.0]])
+    )
+
+    # Check both updates applied
+    assert jnp.allclose(updated[0, 0], 10.0)
+    assert jnp.allclose(updated[1:3, 0], jnp.array([20.0, 30.0]))
+
+
+def test_flatten_pytree_with_sample_dims():
+    """Test flattening with sample_ndims > 0."""
+    # Convention: (*sample, *event, *batch)
+    # PyTree with sample dimension
+    pytree = {
+        'a': jnp.array([
+            [[1.0], [2.0]],  # sample 0: 2 events, 1 batch
+            [[3.0], [4.0]]   # sample 1: 2 events, 1 batch
+        ]),  # shape: (2 samples, 2 events, 1 batch)
+        'b': jnp.array([
+            [[5.0]],  # sample 0: 1 event, 1 batch
+            [[6.0]]   # sample 1: 1 event, 1 batch
+        ])  # shape: (2 samples, 1 event, 1 batch)
+    }
+
+    flat_array, slices_dict = flatten_pytree(
+        pytree,
+        sample_ndims=1,
+        batch_ndims={'a': 1, 'b': 1}
+    )
+
+    # Expected shape: (n_samples, total_event, batch)
+    # = (2, 2+1, 1) = (2, 3, 1)
+    assert flat_array.shape == (2, 3, 1)
+
+    # Check sample 0
+    assert jnp.allclose(
+        flat_array[0, :, 0], jnp.array([1.0, 2.0, 5.0])
+    )
+
+    # Check sample 1
+    assert jnp.allclose(
+        flat_array[1, :, 0], jnp.array([3.0, 4.0, 6.0])
+    )
+
+    # Check slices are same for all samples
+    assert slices_dict['a']['offset'] == 0
+    assert slices_dict['b']['offset'] == 2
+
+
+def test_flatten_pytree_with_multiple_sample_dims():
+    """Test flattening with sample_ndims=2."""
+    # PyTree with 2 sample dimensions
+    pytree = {
+        'param': jnp.array([
+            [  # sample group 0
+                [[1.0]],  # sample 0
+                [[2.0]]   # sample 1
+            ],
+            [  # sample group 1
+                [[3.0]],  # sample 0
+                [[4.0]]   # sample 1
+            ]
+        ])  # shape: (2, 2, 1, 1)
+    }
+
+    flat_array, slices_dict = flatten_pytree(
+        pytree,
+        sample_ndims=2,
+        batch_ndims={'param': 1}
+    )
+
+    # Expected shape: (2, 2, 1, 1)
+    assert flat_array.shape == (2, 2, 1, 1)
+
+    # Check values preserved across sample dims
+    assert jnp.allclose(flat_array[0, 0, 0, 0], 1.0)
+    assert jnp.allclose(flat_array[0, 1, 0, 0], 2.0)
+    assert jnp.allclose(flat_array[1, 0, 0, 0], 3.0)
+    assert jnp.allclose(flat_array[1, 1, 0, 0], 4.0)

--- a/test/test_preprocessing/test_functional_inputs.py
+++ b/test/test_preprocessing/test_functional_inputs.py
@@ -1,0 +1,241 @@
+"""Tests for functional input processing utilities."""
+
+import jax.numpy as jnp
+import pytest
+from jaxtyping import Array
+
+
+@pytest.fixture
+def simple_tokens_slices():
+    """Simple slices dict matching token structure."""
+    return {
+        'mu': {
+            'offset': 0,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        },
+        'theta': {
+            'offset': 1,
+            'event_shape': (5,),
+            'batch_shape': (1,)
+        },
+        'obs': {
+            'offset': 6,
+            'event_shape': (5, 3),
+            'batch_shape': (1,)
+        }
+    }
+
+
+@pytest.fixture
+def matching_functional_inputs():
+    """Functional inputs with matching shapes to token structure."""
+    return {
+        'mu': jnp.zeros((1, 1)),  # (event=1, batch=1)
+        'theta': jnp.zeros((5, 1)),  # (event=5, batch=1)
+        'obs': jnp.ones((5, 3, 1))  # (event1=5, event2=3, batch=1)
+    }
+
+
+@pytest.fixture
+def padded_functional_inputs():
+    """Functional inputs requiring padding to max batch."""
+    return {
+        'mu': jnp.zeros((1, 1)),  # (event=1, batch=1) - needs padding to 2
+        'theta': jnp.zeros((5, 1)),  # (event=5, batch=1) - needs padding to 2
+        'obs': jnp.ones((5, 3, 2))  # (event1=5, event2=3, batch=2) - max
+    }
+
+
+def test_flatten_functional_inputs_matching_shapes(
+    simple_tokens_slices,
+    matching_functional_inputs
+):
+    """Test flattening functional inputs with matching shapes."""
+    from tfmpe.preprocessing.functional_inputs import (
+        flatten_functional_inputs
+    )
+
+    result = flatten_functional_inputs(
+        matching_functional_inputs,
+        simple_tokens_slices,
+        sample_ndims=0
+    )
+
+    # Check shape: (total_tokens=21, max_batch=1)
+    assert result is not None
+    assert result.shape == (21, 1)
+
+    # Check mu values (offset 0, size 1)
+    assert jnp.allclose(result[0, 0], 0.0)
+
+    # Check theta values (offset 1, size 5)
+    assert jnp.allclose(result[1:6, 0], 0.0)
+
+    # Check obs values (offset 6, size 15)
+    assert jnp.allclose(result[6:21, 0], 1.0)
+
+
+def test_flatten_functional_inputs_with_padding(
+    simple_tokens_slices,
+    padded_functional_inputs
+):
+    """Test flattening functional inputs requiring padding."""
+    from tfmpe.preprocessing.functional_inputs import (
+        flatten_functional_inputs
+    )
+
+    result = flatten_functional_inputs(
+        padded_functional_inputs,
+        simple_tokens_slices,
+        sample_ndims=0,
+        pad_value=-1e8
+    )
+
+    # Check shape: (total_tokens=21, max_batch=2)
+    assert result is not None
+    assert result.shape == (21, 2)
+
+    # Check mu padding (offset 0, size 1)
+    # mu has batch=1, so index 1 should be padded
+    assert jnp.allclose(result[0, 0], 0.0)
+    assert jnp.allclose(result[0, 1], -1e8)
+
+    # Check theta padding (offset 1, size 5)
+    # theta has batch=1, so index 1 should be padded
+    assert jnp.allclose(result[1:6, 0], 0.0)
+    assert jnp.allclose(result[1:6, 1], -1e8)
+
+    # Check obs no padding needed (offset 6, size 15)
+    # obs has batch=2, so both indices should be valid
+    assert jnp.allclose(result[6:21, 0], 1.0)
+    assert jnp.allclose(result[6:21, 1], 1.0)
+
+
+def test_flatten_functional_inputs_none_returns_none():
+    """Test that None functional inputs return None."""
+    from tfmpe.preprocessing.functional_inputs import (
+        flatten_functional_inputs
+    )
+
+    result = flatten_functional_inputs(
+        None,
+        {},
+        sample_ndims=0
+    )
+
+    assert result is None
+
+
+def test_flatten_functional_inputs_alignment_with_token_slices(
+    simple_tokens_slices
+):
+    """Test that functional inputs align correctly with token offsets."""
+    from tfmpe.preprocessing.functional_inputs import (
+        flatten_functional_inputs
+    )
+
+    # Create functional inputs with distinct values per key
+    functional_inputs = {
+        'mu': jnp.full((1, 1), 10.0),  # (event=1, batch=1)
+        'theta': jnp.full((5, 1), 20.0),  # (event=5, batch=1)
+        'obs': jnp.full((5, 3, 1), 30.0)  # (event1=5, event2=3, batch=1)
+    }
+
+    result = flatten_functional_inputs(
+        functional_inputs,
+        simple_tokens_slices,
+        sample_ndims=0
+    )
+
+    # Verify each key's functional inputs appear at correct offsets
+    assert result is not None
+    mu_slice = simple_tokens_slices['mu']
+    theta_slice = simple_tokens_slices['theta']
+    obs_slice = simple_tokens_slices['obs']
+
+    mu_offset = mu_slice['offset']
+    mu_size = 1  # prod(event_shape)
+    assert jnp.allclose(
+        result[mu_offset:mu_offset + mu_size, 0],
+        10.0
+    )
+
+    theta_offset = theta_slice['offset']
+    theta_size = 5  # prod(event_shape)
+    assert jnp.allclose(
+        result[theta_offset:theta_offset + theta_size, 0],
+        20.0
+    )
+
+    obs_offset = obs_slice['offset']
+    obs_size = 15  # prod(event_shape) = 5*3
+    assert jnp.allclose(
+        result[obs_offset:obs_offset + obs_size, 0],
+        30.0
+    )
+
+
+def test_flatten_functional_inputs_subset_of_keys(
+    simple_tokens_slices
+):
+    """Test flattening when functional inputs are a subset of keys."""
+    from tfmpe.preprocessing.functional_inputs import (
+        flatten_functional_inputs
+    )
+
+    # Only provide functional inputs for 'obs', not 'mu' or 'theta'
+    functional_inputs = {
+        'obs': jnp.full((5, 3, 1), 30.0)
+    }
+
+    result = flatten_functional_inputs(
+        functional_inputs,
+        simple_tokens_slices,
+        sample_ndims=0,
+        pad_value=-1e8
+    )
+
+    # Check shape: (total_tokens=21, batch=1)
+    assert result is not None
+    assert result.shape == (21, 1)
+
+    # Check mu is padded (offset 0, size 1)
+    assert jnp.allclose(result[0, 0], -1e8)
+
+    # Check theta is padded (offset 1, size 5)
+    assert jnp.allclose(result[1:6, 0], -1e8)
+
+    # Check obs has values (offset 6, size 15)
+    assert jnp.allclose(result[6:21, 0], 30.0)
+
+
+@pytest.mark.parametrize("sample_ndims", [0, 1, 2])
+def test_flatten_functional_inputs_with_sample_dims(
+    simple_tokens_slices,
+    sample_ndims
+):
+    """Test flattening with different sample dimensions."""
+    from tfmpe.preprocessing.functional_inputs import (
+        flatten_functional_inputs
+    )
+
+    # Add sample dimensions to functional inputs
+    sample_shape = (2,) * sample_ndims if sample_ndims > 0 else ()
+
+    functional_inputs = {
+        'mu': jnp.zeros(sample_shape + (1, 1)),
+        'theta': jnp.zeros(sample_shape + (5, 1)),
+        'obs': jnp.ones(sample_shape + (5, 3, 1))
+    }
+
+    result = flatten_functional_inputs(
+        functional_inputs,
+        simple_tokens_slices,
+        sample_ndims=sample_ndims
+    )
+
+    # Check shape: (*sample_shape, total_tokens=21, batch=1)
+    assert result is not None
+    expected_shape = sample_shape + (21, 1)
+    assert result.shape == expected_shape

--- a/test/test_preprocessing/test_masks.py
+++ b/test/test_preprocessing/test_masks.py
@@ -69,7 +69,6 @@ def test_self_attention_mask_local_independence(simple_slices):
     assert mask.shape == (5, 5)
     assert jnp.allclose(mask, expected)
 
-
 def test_self_attention_mask_cross_independence(simple_slices):
     """Test self-attention mask with cross independence."""
     independence = {
@@ -91,7 +90,6 @@ def test_self_attention_mask_cross_independence(simple_slices):
 
     assert mask.shape == (5, 5)
     assert jnp.allclose(mask, expected)
-
 
 def test_self_attention_mask_cross_local_with_functional_inputs(
     simple_slices
@@ -118,7 +116,6 @@ def test_self_attention_mask_cross_local_with_functional_inputs(
     assert mask.shape == (5, 5)
     assert jnp.allclose(mask, expected)
 
-
 def test_self_attention_mask_cross_local_diagonal(simple_slices):
     """Test cross-local mask with diagonal (None idx_map)."""
     # When idx_map is None, it's diagonal only
@@ -141,7 +138,6 @@ def test_self_attention_mask_cross_local_diagonal(simple_slices):
 
     assert mask.shape == (5, 5)
     assert jnp.allclose(mask, expected)
-
 
 def test_self_attention_mask_combined_rules(
     simple_slices,
@@ -168,7 +164,6 @@ def test_self_attention_mask_combined_rules(
 
     assert mask.shape == (5, 5)
     assert jnp.allclose(mask, expected)
-
 
 def test_cross_local_multidim_event_shapes():
     """Test cross_local with multi-dimensional event shapes."""
@@ -333,7 +328,6 @@ def test_cross_attention_mask_basic():
     assert mask.shape == (2, 3)
     assert jnp.allclose(mask, expected)
 
-
 def test_cross_attention_mask_with_cross_local():
     """Test cross-attention mask with cross_local independence."""
     query_slices = {
@@ -371,6 +365,7 @@ def test_cross_attention_mask_with_cross_local():
     ], dtype=np.float32)
 
     assert mask.shape == (2, 2)
+
     assert jnp.allclose(mask, expected)
 
 

--- a/test/test_preprocessing/test_reconstruct.py
+++ b/test/test_preprocessing/test_reconstruct.py
@@ -1,0 +1,287 @@
+"""Tests for PyTree reconstruction utilities.
+
+Tests verify reconstruction of hierarchical parameter structures from flat
+arrays using slice metadata, with support for selective key reconstruction.
+"""
+
+import jax.numpy as jnp
+import pytest
+from jaxtyping import Array
+
+from tfmpe.preprocessing import decode_pytree, decode_pytree_keys
+
+
+def test_decode_pytree_full():
+    """Test full PyTree reconstruction."""
+    # Flat array: [1.0, 2.0, 0.5] representing mu=[1.0, 2.0], sigma=[0.5]
+    flat_array = jnp.array([[1.0, 2.0, 0.5]]).T  # (3, 1)
+
+    slices_dict = {
+        'mu': {
+            'offset': 0,
+            'event_shape': (2,),
+            'batch_shape': (1,)
+        },
+        'sigma': {
+            'offset': 2,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        }
+    }
+
+    # Reconstruct
+    reconstructed = decode_pytree(
+        flat_array,
+        slices_dict,
+        sample_shape=()
+    )
+
+    # Verify all keys present
+    assert set(reconstructed.keys()) == {'mu', 'sigma'}
+
+    # Verify shapes and values match
+    assert reconstructed['mu'].shape == (2, 1)
+    assert jnp.allclose(reconstructed['mu'], jnp.array([[1.0], [2.0]]))
+    assert reconstructed['sigma'].shape == (1, 1)
+    assert jnp.allclose(reconstructed['sigma'], jnp.array([[0.5]]))
+
+
+def test_decode_pytree_keys_selective():
+    """Test selective key reconstruction with decode_pytree_keys()."""
+    # Flat array: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    # Representing: mu=[1.0], sigma=[2.0, 3.0], obs=[4.0, 5.0, 6.0]
+    flat_array = jnp.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]).T  # (6, 1)
+
+    slices_dict = {
+        'mu': {
+            'offset': 0,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        },
+        'sigma': {
+            'offset': 1,
+            'event_shape': (2,),
+            'batch_shape': (1,)
+        },
+        'obs': {
+            'offset': 3,
+            'event_shape': (3,),
+            'batch_shape': (1,)
+        }
+    }
+
+    # Reconstruct only mu and obs
+    selected_keys = ['mu', 'obs']
+    reconstructed = decode_pytree_keys(
+        flat_array,
+        slices_dict,
+        sample_shape=(),
+        keys=selected_keys
+    )
+
+    # Verify only selected keys present
+    assert set(reconstructed.keys()) == set(selected_keys)
+
+    # Verify values match
+    assert jnp.allclose(reconstructed['mu'], jnp.array([[1.0]]))
+    assert jnp.allclose(reconstructed['obs'], jnp.array([[4.0], [5.0], [6.0]]))
+
+    # Verify sigma not present
+    assert 'sigma' not in reconstructed
+
+
+def test_decode_pytree_key_order_preserved():
+    """Test that key order is consistent with slices_dict."""
+    # Flat array with 3 keys in specific order
+    flat_array = jnp.array([[1.0, 2.0, 3.0, 4.0]]).T  # (4, 1)
+
+    # Note: dict insertion order is preserved in Python 3.7+
+    slices_dict = {
+        'z': {
+            'offset': 0,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        },
+        'a': {
+            'offset': 1,
+            'event_shape': (2,),
+            'batch_shape': (1,)
+        },
+        'x': {
+            'offset': 3,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        }
+    }
+
+    # Reconstruct
+    reconstructed = decode_pytree(
+        flat_array,
+        slices_dict,
+        sample_shape=()
+    )
+
+    # Verify key order matches slices_dict order
+    assert list(reconstructed.keys()) == list(slices_dict.keys())
+    assert list(reconstructed.keys()) == ['z', 'a', 'x']
+
+
+@pytest.mark.parametrize(
+    "sample_ndims,sample_shape,flat_array,expected_shapes",
+    [
+        # No sample dims
+        (
+            0,
+            (),
+            jnp.array([[1.0, 2.0, 3.0]]).T,  # (3, 1)
+            {'a': (2, 1), 'b': (1, 1)}
+        ),
+        # 1 sample dim
+        (
+            1,
+            (2,),
+            jnp.array([
+                [[1.0], [2.0], [3.0]],  # sample 0
+                [[4.0], [5.0], [6.0]]   # sample 1
+            ]),  # (2, 3, 1)
+            {'a': (2, 2, 1), 'b': (2, 1, 1)}
+        ),
+        # 2 sample dims
+        (
+            2,
+            (2, 2),
+            jnp.ones((2, 2, 3, 1)),  # (2, 2, 3, 1)
+            {'a': (2, 2, 2, 1), 'b': (2, 2, 1, 1)}
+        ),
+    ]
+)
+def test_decode_pytree_with_different_sample_dims(
+    sample_ndims,
+    sample_shape,
+    flat_array,
+    expected_shapes
+):
+    """Test shape preservation with different batch dims."""
+    slices_dict = {
+        'a': {
+            'offset': 0,
+            'event_shape': (2,),
+            'batch_shape': (1,)
+        },
+        'b': {
+            'offset': 2,
+            'event_shape': (1,),
+            'batch_shape': (1,)
+        }
+    }
+
+    # Reconstruct
+    reconstructed = decode_pytree(
+        flat_array,
+        slices_dict,
+        sample_shape=sample_shape
+    )
+
+    # Verify shapes preserved
+    for key in ['a', 'b']:
+        assert reconstructed[key].shape == expected_shapes[key]
+
+
+def test_decode_pytree_with_padding():
+    """Test reconstruction correctly handles padded batch dimensions."""
+    # Flat array with padding:
+    # a=[1.0, 2.0, 3.0] (batch size 3), b=[4.0, -999, -999] (batch size 1)
+    flat_array = jnp.array([
+        [1.0, 2.0, 3.0],
+        [4.0, -999.0, -999.0]
+    ])  # (2, 3)
+
+    slices_dict = {
+        'a': {
+            'offset': 0,
+            'event_shape': (1,),
+            'batch_shape': (3,)  # Actual batch size 3
+        },
+        'b': {
+            'offset': 1,
+            'event_shape': (1,),
+            'batch_shape': (1,)  # Actual batch size 1 (padded to 3)
+        }
+    }
+
+    # Reconstruct
+    reconstructed = decode_pytree(
+        flat_array,
+        slices_dict,
+        sample_shape=()
+    )
+
+    # Verify shapes match (padding removed)
+    assert reconstructed['a'].shape == (1, 3)
+    assert reconstructed['b'].shape == (1, 1)
+
+    # Verify values match (no padding in output)
+    assert jnp.allclose(reconstructed['a'], jnp.array([[1.0, 2.0, 3.0]]))
+    assert jnp.allclose(reconstructed['b'], jnp.array([[4.0]]))
+
+
+def test_decode_pytree_error_on_invalid_slice():
+    """Verify error on invalid slice metadata."""
+    # Create flat array
+    flat_array = jnp.array([[1.0, 2.0, 3.0]]).T  # (3, 1)
+
+    # Invalid slices: offset + event_size exceeds array size
+    invalid_slices = {
+        'a': {
+            'offset': 0,
+            'event_shape': (5,),  # Too large!
+            'batch_shape': (1,)
+        }
+    }
+
+    # Should raise error (IndexError or ValueError)
+    with pytest.raises((IndexError, ValueError)):
+        decode_pytree(
+            flat_array,
+            invalid_slices,
+            sample_shape=()
+        )
+
+
+def test_decode_pytree_roundtrip_with_multidim_events():
+    """Test round-trip with multi-dimensional event shapes."""
+    # Flat array: 2x2 matrix (flattened) + 3-vector (flattened)
+    # [1, 2, 3, 4, 5, 6, 7]
+    flat_array = jnp.array([
+        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    ]).T  # (7, 1)
+
+    slices_dict = {
+        'matrix': {
+            'offset': 0,
+            'event_shape': (2, 2),  # 2x2 matrix
+            'batch_shape': (1,)
+        },
+        'vector': {
+            'offset': 4,
+            'event_shape': (3, 1),  # 3x1 vector
+            'batch_shape': (1,)
+        }
+    }
+
+    # Reconstruct
+    reconstructed = decode_pytree(
+        flat_array,
+        slices_dict,
+        sample_shape=()
+    )
+
+    # Verify shapes
+    assert reconstructed['matrix'].shape == (2, 2, 1)
+    assert reconstructed['vector'].shape == (3, 1, 1)
+
+    # Verify values
+    expected_matrix = jnp.array([[[1.0], [2.0]], [[3.0], [4.0]]])
+    expected_vector = jnp.array([[[5.0]], [[6.0]], [[7.0]]])
+    assert jnp.allclose(reconstructed['matrix'], expected_matrix)
+    assert jnp.allclose(reconstructed['vector'], expected_vector)

--- a/tfmpe/preprocessing/__init__.py
+++ b/tfmpe/preprocessing/__init__.py
@@ -1,5 +1,11 @@
 """Pipelines for processing datasets for use with the estimators."""
 
+from tfmpe.preprocessing.flatten import flatten_pytree, update_flat_array
+from tfmpe.preprocessing.functional_inputs import flatten_functional_inputs
+from tfmpe.preprocessing.reconstruct import (
+    decode_pytree,
+    decode_pytree_keys,
+)
 from tfmpe.preprocessing.masks import (
     build_self_attention_mask,
     build_cross_attention_mask,
@@ -7,6 +13,11 @@ from tfmpe.preprocessing.masks import (
 )
 
 __all__ = [
+    "flatten_pytree",
+    "update_flat_array",
+    "flatten_functional_inputs",
+    "decode_pytree",
+    "decode_pytree_keys",
     "build_self_attention_mask",
     "build_cross_attention_mask",
     "build_padding_mask"

--- a/tfmpe/preprocessing/__init__.py
+++ b/tfmpe/preprocessing/__init__.py
@@ -1,5 +1,4 @@
 """Pipelines for processing datasets for use with the estimators."""
-
 from tfmpe.preprocessing.flatten import (
     flatten_leaf,
     flatten_pytree,
@@ -10,6 +9,12 @@ from tfmpe.preprocessing.reconstruct import (
     decode_pytree,
     decode_pytree_keys,
 )
+from tfmpe.preprocessing.masks import (
+    build_self_attention_mask,
+    build_cross_attention_mask,
+    build_padding_mask
+)
+
 from tfmpe.preprocessing.masks import (
     build_self_attention_mask,
     build_cross_attention_mask,

--- a/tfmpe/preprocessing/__init__.py
+++ b/tfmpe/preprocessing/__init__.py
@@ -1,6 +1,10 @@
 """Pipelines for processing datasets for use with the estimators."""
 
-from tfmpe.preprocessing.flatten import flatten_pytree, update_flat_array
+from tfmpe.preprocessing.flatten import (
+    flatten_leaf,
+    flatten_pytree,
+    update_flat_array,
+)
 from tfmpe.preprocessing.functional_inputs import flatten_functional_inputs
 from tfmpe.preprocessing.reconstruct import (
     decode_pytree,
@@ -13,6 +17,7 @@ from tfmpe.preprocessing.masks import (
 )
 
 __all__ = [
+    "flatten_leaf",
     "flatten_pytree",
     "update_flat_array",
     "flatten_functional_inputs",

--- a/tfmpe/preprocessing/flatten.py
+++ b/tfmpe/preprocessing/flatten.py
@@ -1,12 +1,74 @@
 """PyTree flattening utilities for parameter processing."""
 
-import math
 from typing import Any, Dict, Tuple
 
 import jax.numpy as jnp
 from jaxtyping import Array
 
-from tfmpe.preprocessing.utils import flatten_leaf, size_along_axes
+from tfmpe.preprocessing.utils import size_along_axes
+
+
+def flatten_leaf(
+    leaf: Array,
+    sample_ndims: int,
+    batch_ndims: int,
+    pad_value: float,
+    max_batch_size: int,
+) -> Array:
+    """
+    Flatten a single leaf array.
+
+    Flattens event dimensions and pads batch dimensions to
+    max_batch_size.
+
+    Parameters
+    ----------
+    leaf : Array
+        Array with shape (*sample_dims, *event_dims, *batch_dims)
+    sample_ndims : int
+        Number of leading sample dimensions
+    batch_ndims : int
+        Number of trailing batch dimensions
+    pad_value : float
+        Value to use for padding
+    max_batch_size : int
+        Maximum batch size to pad to
+
+    Returns
+    -------
+    Array
+        Flattened array with shape
+        (*sample_dims, event_flat, batch_flat)
+    """
+    # Extract sample shape
+    sample_shape = leaf.shape[:sample_ndims]
+
+    # Compute flattened sizes
+    event_axes = tuple(
+        range(sample_ndims, len(leaf.shape) - batch_ndims)
+    )
+    batch_axes = tuple(
+        range(len(leaf.shape) - batch_ndims, len(leaf.shape))
+    )
+    flatten_evt_size = size_along_axes(leaf, event_axes)
+    batch_size = size_along_axes(leaf, batch_axes)
+
+    # Reshape to (*sample_dims, flatten_evt_size, batch_size)
+    leaf_reshaped = leaf.reshape(
+        sample_shape + (flatten_evt_size,) + (batch_size,)
+    )
+
+    # Pad batch dim to max_batch_size
+    pad_width = (
+        [(0, 0)] * (sample_ndims + 1) +
+        [(0, max_batch_size - batch_size)]
+    )
+    leaf_reshaped = jnp.pad(
+        leaf_reshaped,
+        pad_width,
+        constant_values=pad_value
+    )
+    return leaf_reshaped
 
 
 def flatten_pytree(

--- a/tfmpe/preprocessing/flatten.py
+++ b/tfmpe/preprocessing/flatten.py
@@ -1,0 +1,190 @@
+"""PyTree flattening utilities for parameter processing."""
+
+import math
+from typing import Any, Dict, Tuple
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from tfmpe.preprocessing.utils import flatten_leaf, size_along_axes
+
+
+def flatten_pytree(
+    pytree: Dict[str, Array],
+    sample_ndims: int,
+    batch_ndims: Dict[str, int],
+    pad_value: float = 0.0
+) -> Tuple[Array, Dict[str, Dict[str, Any]]]:
+    """
+    Flatten a PyTree into a single array with slice metadata.
+
+    Converts a dictionary of parameter arrays into a single flattened
+    array by concatenating along the event dimension. Each array's
+    event dimensions are flattened, and batch dimensions are padded
+    to the maximum batch size across all keys.
+
+    Parameters
+    ----------
+    pytree : Dict[str, Array]
+        Dictionary of parameter arrays. Each array should have shape
+        (*sample_dims, *event_dims, *batch_dims), where event_dims
+        are in the middle and batch_dims are trailing.
+    sample_ndims : int
+        Number of leading sample dimensions (preserved in output).
+    batch_ndims : Dict[str, int]
+        Number of trailing batch dimensions for each key.
+    pad_value : float, optional
+        Value to use for padding smaller batches. Default is 0.0.
+
+    Returns
+    -------
+    flat_array : Array
+        Flattened array with shape
+        (*sample_dims, total_event, max_batch)
+        where total_event is the sum of flattened event dimensions
+        and max_batch is the maximum batch size across all keys.
+    slices_dict : Dict[str, Dict[str, Any]]
+        Metadata for reconstructing original structure. Each key maps
+        to:
+        - 'offset': Starting index in flattened event dimension
+        - 'event_shape': Original event dimensions
+        - 'batch_shape': Original batch dimensions
+
+    Examples
+    --------
+    >>> pytree = {
+    ...     'mu': jnp.array([[1.0, 2.0]]),  # (1, 2)
+    ...     'sigma': jnp.array([[0.5]])  # (1, 1)
+    ... }
+    >>> flat, slices = flatten_pytree(
+    ...     pytree, sample_ndims=0, batch_ndims={'mu': 1, 'sigma': 1}
+    ... )
+    >>> flat.shape
+    (3, 1)
+    """
+    # Determine max batch size
+    max_batch_size = 1
+    for key, leaf in pytree.items():
+        batch_ndim = batch_ndims.get(key, 1)
+        batch_axes = tuple(
+            range(len(leaf.shape) - batch_ndim, len(leaf.shape))
+        )
+        batch_size = size_along_axes(leaf, batch_axes)
+        max_batch_size = max(max_batch_size, batch_size)
+
+    # Flatten each leaf and collect metadata
+    flattened_leaves = []
+    slices = {}
+    current_offset = 0
+
+    for key, leaf in pytree.items():
+        batch_ndim = batch_ndims.get(key, 1)
+
+        # Flatten leaf
+        leaf_flat = flatten_leaf(
+            leaf,
+            sample_ndims,
+            batch_ndim,
+            pad_value,
+            max_batch_size
+        )
+
+        # leaf_flat shape: (*sample_dims, flatten_evt_size, max_batch)
+        block_size = leaf_flat.shape[sample_ndims]
+
+        # Store metadata
+        event_shape = leaf.shape[sample_ndims:-batch_ndim]
+        batch_shape = leaf.shape[-batch_ndim:]
+        slices[key] = {
+            "offset": current_offset,
+            "event_shape": event_shape,
+            "batch_shape": batch_shape
+        }
+        current_offset += block_size
+        flattened_leaves.append(leaf_flat)
+
+    # Concatenate along event dimension (axis=sample_ndims)
+    flat_data = jnp.concatenate(flattened_leaves, axis=sample_ndims)
+    return flat_data, slices
+
+
+def update_flat_array(
+    flat_array: Array,
+    slices_dict: Dict[str, Dict[str, Any]],
+    key: str,
+    new_values: Array
+) -> Array:
+    """
+    Update values for a specific key in the flat array.
+
+    Creates a new flat array with the specified key's values replaced.
+    The new values are flattened and inserted at the correct offset.
+
+    Parameters
+    ----------
+    flat_array : Array
+        The flat array to update, with shape
+        (*sample_dims, total_event, max_batch)
+    slices_dict : Dict[str, Dict[str, Any]]
+        Slice metadata from flatten_pytree
+    key : str
+        Key to update
+    new_values : Array
+        New values for the key, with shape matching the original
+        (batch_shape, *event_shape)
+
+    Returns
+    -------
+    Array
+        Updated flat array with the same shape as flat_array
+
+    Examples
+    --------
+    >>> flat = jnp.array([[1.0, 2.0, 3.0]]).T
+    >>> slices = {
+    ...     'a': {'offset': 0, 'event_shape': (2,),
+    ...           'batch_shape': (1,)},
+    ...     'b': {'offset': 2, 'event_shape': (1,),
+    ...           'batch_shape': (1,)}
+    ... }
+    >>> updated = update_flat_array(
+    ...     flat, slices, 'b', jnp.array([[99.0]])
+    ... )
+    >>> updated[2, 0]
+    Array(99., dtype=float32)
+    """
+    slice_info = slices_dict[key]
+    offset = slice_info['offset']
+    event_shape = slice_info['event_shape']
+    batch_shape = slice_info['batch_shape']
+
+    # Flatten new values
+    # new_values has shape (*batch_shape, *event_shape)
+    batch_axes = tuple(range(len(batch_shape)))
+    event_axes = tuple(range(len(batch_shape), len(new_values.shape)))
+    batch_size = size_along_axes(new_values, batch_axes)
+    event_size = size_along_axes(new_values, event_axes)
+
+    # Reshape to (event_size, batch_size)
+    new_values_flat = new_values.reshape(
+        (batch_size,) + event_shape
+    ).reshape((batch_size, event_size)).T
+
+    # Update the flat array
+    # Handle both with and without sample dimensions
+    if flat_array.ndim == 2:
+        # Shape: (total_event, max_batch)
+        updated = flat_array.at[
+            offset:offset + event_size,
+            :batch_size
+        ].set(new_values_flat)
+    else:
+        # Shape: (*sample_dims, total_event, max_batch)
+        # For now, assume updating all samples identically
+        updated = flat_array.at[
+            ...,
+            offset:offset + event_size,
+            :batch_size
+        ].set(new_values_flat)
+
+    return updated

--- a/tfmpe/preprocessing/functional_inputs.py
+++ b/tfmpe/preprocessing/functional_inputs.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, Optional
 import jax.numpy as jnp
 from jaxtyping import Array
 
-from tfmpe.preprocessing.utils import flatten_leaf
+from tfmpe.preprocessing.flatten import flatten_leaf
 
 
 def flatten_functional_inputs(

--- a/tfmpe/preprocessing/functional_inputs.py
+++ b/tfmpe/preprocessing/functional_inputs.py
@@ -1,0 +1,125 @@
+"""Functional input processing utilities for parameter tokens."""
+
+import math
+from typing import Dict, Any, Optional
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from tfmpe.preprocessing.utils import flatten_leaf
+
+
+def flatten_functional_inputs(
+    functional_inputs: Optional[Dict[str, Array]],
+    slices: Dict[str, Dict[str, Any]],
+    sample_ndims: int,
+    pad_value: float = -1e8,
+) -> Optional[Array]:
+    """
+    Flatten functional inputs aligned with token slices.
+
+    Functional inputs (e.g., observation times, spatial coordinates)
+    are auxiliary data that vary with the parameter structure. This
+    function flattens them to match the flattened token structure,
+    with padding for keys that have smaller batch dimensions or
+    missing functional inputs.
+
+    The legacy code assumes functional inputs always have batch_ndims=1
+    (the last dimension is the batch dimension).
+
+    Parameters
+    ----------
+    functional_inputs : Optional[Dict[str, Array]]
+        Dictionary of functional input arrays. Each array should have
+        shape (*sample_dims, *event_dims, batch_dim). The last
+        dimension is treated as the batch dimension. If None,
+        returns None.
+    slices : Dict[str, Dict[str, Any]]
+        Slice metadata from flatten_pytree, containing 'offset',
+        'event_shape', and 'batch_shape' for each key.
+    sample_ndims : int
+        Number of leading sample dimensions to preserve.
+    pad_value : float, optional
+        Value to use for padding. Default is -1e8 (sentinel value).
+
+    Returns
+    -------
+    Optional[Array]
+        Flattened functional inputs with shape
+        (*sample_dims, total_event, max_batch), or None if
+        functional_inputs is None.
+
+    Examples
+    --------
+    >>> functional_inputs = {
+    ...     'obs': jnp.ones((5, 3, 1))  # (event1, event2, batch)
+    ... }
+    >>> slices = {
+    ...     'obs': {
+    ...         'offset': 0,
+    ...         'event_shape': (5, 3),
+    ...         'batch_shape': (1,)
+    ...     }
+    ... }
+    >>> result = flatten_functional_inputs(
+    ...     functional_inputs, slices, sample_ndims=0
+    ... )
+    >>> result.shape
+    (15, 1)
+    """
+    if functional_inputs is None:
+        return None
+
+    # Determine max batch size - functional inputs always have
+    # batch_ndims=1 (last dim)
+    max_batch_size = 1
+    for key, f_in in functional_inputs.items():
+        if key in slices:
+            batch_size = f_in.shape[-1]
+            max_batch_size = max(max_batch_size, batch_size)
+
+    # Compute total event size from slices
+    total_event_size = sum(
+        math.prod(info['event_shape']) for info in slices.values()
+    )
+
+    # Get sample shape from first functional input
+    first_key = next(iter(functional_inputs.keys()))
+    sample_shape = functional_inputs[first_key].shape[:sample_ndims]
+
+    # Initialize output array filled with pad_value
+    output_shape = sample_shape + (total_event_size, max_batch_size)
+    output = jnp.full(output_shape, pad_value)
+
+    # Process each key in slices order
+    for key, slice_info in slices.items():
+        offset = slice_info['offset']
+        event_shape = slice_info['event_shape']
+        event_size = math.prod(event_shape)
+
+        if key not in functional_inputs:
+            # Key has no functional inputs, leave as pad_value
+            continue
+
+        f_in = functional_inputs[key]
+
+        # Flatten with batch_ndims=1 (legacy behavior)
+        f_in_flat = flatten_leaf(
+            f_in,
+            sample_ndims,
+            batch_ndims=1,
+            pad_value=pad_value,
+            max_batch_size=max_batch_size
+        )
+
+        # Insert into output at correct offset
+        if sample_ndims == 0:
+            output = output.at[offset:offset + event_size, :].set(
+                f_in_flat
+            )
+        else:
+            output = output.at[
+                ..., offset:offset + event_size, :
+            ].set(f_in_flat)
+
+    return output

--- a/tfmpe/preprocessing/masks.py
+++ b/tfmpe/preprocessing/masks.py
@@ -5,7 +5,7 @@ from independence specifications and slice metadata.
 """
 
 from math import prod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import jax.numpy as jnp
 import numpy as np

--- a/tfmpe/preprocessing/reconstruct.py
+++ b/tfmpe/preprocessing/reconstruct.py
@@ -1,0 +1,164 @@
+"""PyTree reconstruction utilities for parameter processing."""
+
+import math
+from typing import Any, Dict, Optional, Tuple
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+
+def decode_pytree(
+    flat_array: Array,
+    slices_dict: Dict[str, Dict[str, Any]],
+    sample_shape: Tuple[int, ...],
+    is_subset: bool = False
+) -> Dict[str, Array]:
+    """
+    Reconstruct PyTree from flat array using slice metadata.
+
+    Converts a flattened array back into a dictionary of parameter arrays
+    using the slice metadata from flatten_pytree. Removes padding and
+    restores original event and batch shapes.
+
+    Parameters
+    ----------
+    flat_array : Array
+        Flattened array with shape (*sample_shape, total_event, max_batch)
+    slices_dict : Dict[str, Dict[str, Any]]
+        Slice metadata from flatten_pytree. Each key maps to:
+        - 'offset': Starting index in flattened event dimension
+        - 'event_shape': Original event dimensions
+        - 'batch_shape': Original batch dimensions
+    sample_shape : Tuple[int, ...]
+        Shape of sample dimensions (empty tuple if no sample dims)
+    is_subset : bool, optional
+        If True, only validate that slices don't exceed bounds.
+        If False, validate that slices exactly match flat array size.
+        Default is False.
+
+    Returns
+    -------
+    Dict[str, Array]
+        Dictionary of reconstructed arrays, each with shape
+        (*sample_shape, *event_shape, *batch_shape)
+
+    Examples
+    --------
+    >>> flat = jnp.array([[1.0, 2.0, 0.5]]).T
+    >>> slices = {
+    ...     'mu': {'offset': 0, 'event_shape': (2,),
+    ...            'batch_shape': (1,)},
+    ...     'sigma': {'offset': 2, 'event_shape': (1,),
+    ...               'batch_shape': (1,)}
+    ... }
+    >>> result = decode_pytree(flat, slices, sample_shape=())
+    >>> result['mu'].shape
+    (2, 1)
+    """
+    # Get total size of flat array along event dimension
+    event_dim_idx = len(sample_shape)
+    total_event_size = flat_array.shape[event_dim_idx]
+
+    # Validate slice metadata
+    slice_event_sizes = [
+        math.prod(info['event_shape']) if info['event_shape'] else 1
+        for info in slices_dict.values()
+    ]
+    expected_total = sum(slice_event_sizes)
+
+    if is_subset:
+        # For subset decoding, just check we don't exceed bounds
+        if expected_total > total_event_size:
+            raise ValueError(
+                f"Invalid slices. Slice event sizes {slice_event_sizes} "
+                f"sum to {expected_total} exceeds flat event size "
+                f"{total_event_size}"
+            )
+    else:
+        # For full decoding, require exact match
+        if expected_total != total_event_size:
+            raise ValueError(
+                f"Invalid slices. Slice event sizes {slice_event_sizes} "
+                f"sum to {expected_total} but flat event size is "
+                f"{total_event_size}"
+            )
+
+    reconstructed = {}
+
+    for key, slice_info in slices_dict.items():
+        offset = slice_info['offset']
+        event_shape = slice_info['event_shape']
+        batch_shape = slice_info['batch_shape']
+
+        # Calculate event and batch sizes
+        event_size = math.prod(event_shape) if event_shape else 1
+        batch_size = math.prod(batch_shape) if batch_shape else 1
+
+        # Extract slice from flat array
+        # Shape: (*sample_shape, event_size, max_batch)
+        block_slice = flat_array[..., offset:offset + event_size, :]
+
+        # Extract only the valid batch elements (remove padding)
+        # Shape: (*sample_shape, event_size, batch_size)
+        block_slice = block_slice[..., :batch_size]
+
+        # Reshape to final shape
+        new_shape = sample_shape + event_shape + batch_shape
+        reconstructed[key] = jnp.reshape(block_slice, new_shape)
+
+    return reconstructed
+
+
+def decode_pytree_keys(
+    flat_array: Array,
+    slices_dict: Dict[str, Dict[str, Any]],
+    sample_shape: Tuple[int, ...],
+    keys: list[str]
+) -> Dict[str, Array]:
+    """
+    Reconstruct only specified keys from flat array.
+
+    Similar to decode_pytree, but only reconstructs a subset of keys.
+    Useful when only a portion of the flattened data is needed.
+
+    Parameters
+    ----------
+    flat_array : Array
+        Flattened array with shape (*sample_shape, total_event, max_batch)
+    slices_dict : Dict[str, Dict[str, Any]]
+        Slice metadata from flatten_pytree
+    sample_shape : Tuple[int, ...]
+        Shape of sample dimensions
+    keys : list[str]
+        List of keys to reconstruct
+
+    Returns
+    -------
+    Dict[str, Array]
+        Dictionary containing only the specified keys, each with shape
+        (*sample_shape, *event_shape, *batch_shape)
+
+    Examples
+    --------
+    >>> flat = jnp.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]).T
+    >>> slices = {
+    ...     'mu': {'offset': 0, 'event_shape': (1,),
+    ...            'batch_shape': (1,)},
+    ...     'sigma': {'offset': 1, 'event_shape': (2,),
+    ...               'batch_shape': (1,)},
+    ...     'obs': {'offset': 3, 'event_shape': (3,),
+    ...            'batch_shape': (1,)}
+    ... }
+    >>> result = decode_pytree_keys(
+    ...     flat, slices, sample_shape=(), keys=['mu', 'obs']
+    ... )
+    >>> set(result.keys())
+    {'mu', 'obs'}
+    """
+    # Create filtered slices dict with only selected keys
+    filtered_slices = {k: slices_dict[k] for k in keys}
+
+    # Use decode_pytree with filtered slices, marking as subset
+    return decode_pytree(
+        flat_array, filtered_slices, sample_shape, is_subset=True
+    )

--- a/tfmpe/preprocessing/reconstruct.py
+++ b/tfmpe/preprocessing/reconstruct.py
@@ -1,7 +1,7 @@
 """PyTree reconstruction utilities for parameter processing."""
 
 import math
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import jax.numpy as jnp
 from jaxtyping import Array

--- a/tfmpe/preprocessing/utils.py
+++ b/tfmpe/preprocessing/utils.py
@@ -3,7 +3,6 @@
 import math
 from typing import Tuple
 
-import jax.numpy as jnp
 from jaxtyping import Array
 
 
@@ -31,66 +30,3 @@ def size_along_axes(arr: Array, axes: Tuple[int, ...]) -> int:
         return 1
     shape_subset = tuple(arr.shape[ax] for ax in axes)
     return math.prod(shape_subset)
-
-
-def flatten_leaf(
-    leaf: Array,
-    sample_ndims: int,
-    batch_ndims: int,
-    pad_value: float,
-    max_batch_size: int,
-) -> Array:
-    """
-    Flatten a single leaf array.
-
-    Flattens event dimensions and pads batch dimensions to
-    max_batch_size.
-
-    Parameters
-    ----------
-    leaf : Array
-        Array with shape (*sample_dims, *event_dims, *batch_dims)
-    sample_ndims : int
-        Number of leading sample dimensions
-    batch_ndims : int
-        Number of trailing batch dimensions
-    pad_value : float
-        Value to use for padding
-    max_batch_size : int
-        Maximum batch size to pad to
-
-    Returns
-    -------
-    Array
-        Flattened array with shape
-        (*sample_dims, event_flat, batch_flat)
-    """
-    # Extract sample shape
-    sample_shape = leaf.shape[:sample_ndims]
-
-    # Compute flattened sizes
-    event_axes = tuple(
-        range(sample_ndims, len(leaf.shape) - batch_ndims)
-    )
-    batch_axes = tuple(
-        range(len(leaf.shape) - batch_ndims, len(leaf.shape))
-    )
-    flatten_evt_size = size_along_axes(leaf, event_axes)
-    batch_size = size_along_axes(leaf, batch_axes)
-
-    # Reshape to (*sample_dims, flatten_evt_size, batch_size)
-    leaf_reshaped = leaf.reshape(
-        sample_shape + (flatten_evt_size,) + (batch_size,)
-    )
-
-    # Pad batch dim to max_batch_size
-    pad_width = (
-        [(0, 0)] * (sample_ndims + 1) +
-        [(0, max_batch_size - batch_size)]
-    )
-    leaf_reshaped = jnp.pad(
-        leaf_reshaped,
-        pad_width,
-        constant_values=pad_value
-    )
-    return leaf_reshaped

--- a/tfmpe/preprocessing/utils.py
+++ b/tfmpe/preprocessing/utils.py
@@ -1,0 +1,96 @@
+"""Utility functions for parameter processing."""
+
+import math
+from typing import Tuple
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+
+def size_along_axes(arr: Array, axes: Tuple[int, ...]) -> int:
+    """
+    Compute the product of array dimensions along specified axes.
+
+    Parameters
+    ----------
+    arr : Array
+        Input array
+    axes : Tuple[int, ...]
+        Axes to compute size over
+
+    Returns
+    -------
+    int
+        Product of dimensions along specified axes
+
+    Notes
+    -----
+    Uses math.prod to avoid tracer issues in JIT contexts.
+    """
+    if not axes:
+        return 1
+    shape_subset = tuple(arr.shape[ax] for ax in axes)
+    return math.prod(shape_subset)
+
+
+def flatten_leaf(
+    leaf: Array,
+    sample_ndims: int,
+    batch_ndims: int,
+    pad_value: float,
+    max_batch_size: int,
+) -> Array:
+    """
+    Flatten a single leaf array.
+
+    Flattens event dimensions and pads batch dimensions to
+    max_batch_size.
+
+    Parameters
+    ----------
+    leaf : Array
+        Array with shape (*sample_dims, *event_dims, *batch_dims)
+    sample_ndims : int
+        Number of leading sample dimensions
+    batch_ndims : int
+        Number of trailing batch dimensions
+    pad_value : float
+        Value to use for padding
+    max_batch_size : int
+        Maximum batch size to pad to
+
+    Returns
+    -------
+    Array
+        Flattened array with shape
+        (*sample_dims, event_flat, batch_flat)
+    """
+    # Extract sample shape
+    sample_shape = leaf.shape[:sample_ndims]
+
+    # Compute flattened sizes
+    event_axes = tuple(
+        range(sample_ndims, len(leaf.shape) - batch_ndims)
+    )
+    batch_axes = tuple(
+        range(len(leaf.shape) - batch_ndims, len(leaf.shape))
+    )
+    flatten_evt_size = size_along_axes(leaf, event_axes)
+    batch_size = size_along_axes(leaf, batch_axes)
+
+    # Reshape to (*sample_dims, flatten_evt_size, batch_size)
+    leaf_reshaped = leaf.reshape(
+        sample_shape + (flatten_evt_size,) + (batch_size,)
+    )
+
+    # Pad batch dim to max_batch_size
+    pad_width = (
+        [(0, 0)] * (sample_ndims + 1) +
+        [(0, max_batch_size - batch_size)]
+    )
+    leaf_reshaped = jnp.pad(
+        leaf_reshaped,
+        pad_width,
+        constant_values=pad_value
+    )
+    return leaf_reshaped


### PR DESCRIPTION
## Summary
  Phase 1 of preprocessing implementation: adds flattening utilities for converting hierarchical parameter structures (PyTrees) to flat arrays and back, with support for variable batch sizes and padding.

  ## Changes
  ### New Features
  - **Flattening utilities** (`tfmpe/preprocessing/flatten.py`):
    - `flatten_pytree()`: Converts PyTree structures to flat arrays with metadata tracking
    - `decode_pytree()`: Reconstructs PyTrees from flattened representations
    - `update_flat_array()`: Updates specific keys in flattened arrays without full reconstruction

  - **test suite** (`test/test_preprocessing/test_flatten.py`):
    - Round-trip validation (flatten → reconstruct)
    - Variable batch dimension handling
    - Padding behavior verification

(should be pulled out into a different PR)
  - **Design documentation** (`.claude/specs/processing_test/`):
    - Full design document for unified `Tokens` interface
    - Requirements specification for preprocessing infrastructure

  ### Breaking Changes
  None

  ### Fixes
  None

  ---

  ## Reviewer Checklist

  ### All PRs
  - [x] **Correctness**: Logic is sound and implementation is correct
  - [ ] **Testing**: Appropriate tests added/updated
  - [ ] **Benchmarking**: Training/sampling speed impact assessed if relevant
  - [x] **Documentation**: Code comments and docs updated where needed

  ### For AI-Generated PRs
  - [ ] **Entropy**: No unnecessary code duplication, verbose implementations, or misplaced imports
  - [ ] **Test Quality**: Tests genuinely validate intended behavior (check `.claude/spec/{feature}/tasks.md` for requirements)
  - [ ] **Steering Docs**: Fundamental changes to the repo (if any) are reflected in steering documents `.claude/steering/`

  🤖 Co-authored with [Claude Code](https://claude.com/claude-code)