### PR TITLE
Update masking for cudann attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Install the core package with default dependencies:
 pip install -e .
 ```
 
+To install with GPU support (CUDA/cuDNN):
+
+```bash
+pip install -e .[gpu]
+```
+
 ### Development Installation
 
 For development work including testing and type checking:

--- a/test/test_preprocessing/test_tokens_basic.py
+++ b/test/test_preprocessing/test_tokens_basic.py
@@ -302,3 +302,60 @@ def test_pad_to_even_functional_inputs(simple_pytree):
     assert tokens.functional_inputs is not None
     assert tokens.functional_inputs.shape == tokens.data.shape
     assert tokens.data.shape == (8, 1)
+
+def test_attention_mask_cudnn_lengths_with_padding():
+    """cuDNN mask should return int32 per-sample valid lengths."""
+    pytree = {
+        'a': jnp.array([[[1.0], [2.0]], [[3.0], [4.0]]]), # (2, 2, 1)
+        'b': jnp.array([[[5.0]], [[6.0]]]), # (2, 1, 1)
+    }
+
+    tokens = Tokens.from_pytree(
+        pytree,
+        condition=[],
+        sample_ndims=1,
+        batch_ndims={'a': 1, 'b': 1},
+        pad_to_even=True,
+    )
+
+    mask = tokens.attention_mask('cudnn')
+    assert mask is not None
+    assert mask.dtype == jnp.int32
+    assert mask.shape == (2,)
+    assert jnp.array_equal(mask, jnp.array([3, 3], dtype=jnp.int32))
+
+
+def test_attention_mask_dense_for_non_cudnn():
+    """Non-cuDNN attention should receive broadcastable dense mask."""
+    pytree = {
+        'a': jnp.array([[[1.0], [2.0]], [[3.0], [4.0]]]), # (2, 2, 1)
+        'b': jnp.array([[[5.0]], [[6.0]]]), # (2, 1, 1)
+    }
+
+    tokens = Tokens.from_pytree(
+        pytree,
+        condition=[],
+        sample_ndims=1,
+        batch_ndims={'a': 1, 'b': 1},
+        pad_to_even=True,
+    )
+
+    mask = tokens.attention_mask('softmax')
+    assert mask is not None
+    assert mask.shape == (2, 1, 1, 4)
+    assert jnp.array_equal(mask[:, 0, 0, :], tokens.padding_mask)
+
+
+def test_attention_mask_none_without_padding(simple_pytree):
+    """If no padding exists, attention mask should be None."""
+    tokens = Tokens.from_pytree(
+        simple_pytree,
+        condition=['obs'],
+        sample_ndims=0,
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=False,
+    )
+
+    assert tokens.padding_mask is None
+    assert tokens.attention_mask('softmax') is None
+    assert tokens.attention_mask('cudnn') is None

--- a/test/test_preprocessing/test_tokens_basic.py
+++ b/test/test_preprocessing/test_tokens_basic.py
@@ -343,7 +343,7 @@ def test_attention_mask_dense_for_non_cudnn():
     mask = tokens.attention_mask('softmax')
     assert mask is not None
     assert mask.shape == (2, 1, 1, 4)
-    assert jnp.array_equal(mask[:, 0, 0, :], tokens.padding_mask)
+    assert jnp.array_equal(mask[:, 0, 0, :], tokens.padding_mask) #type: ignore
 
 
 def test_attention_mask_none_without_padding(simple_pytree):

--- a/tfmpe/estimators/tfmpe.py
+++ b/tfmpe/estimators/tfmpe.py
@@ -301,6 +301,7 @@ class TFMPE(nnx.Module):
             labels=0,#type: ignore
             position=0,#type: ignore
             condition=0,#type: ignore
+            total_tokens=tokens.total_tokens,
             partition_idx=source_samples.partition_idx,
             padding_mask=None if source_samples.padding_mask is None else 0,#type: ignore
             functional_inputs=None if source_samples.functional_inputs is None else 0,#type: ignore

--- a/tfmpe/estimators/tfmpe.py
+++ b/tfmpe/estimators/tfmpe.py
@@ -301,7 +301,6 @@ class TFMPE(nnx.Module):
             labels=0,#type: ignore
             position=0,#type: ignore
             condition=0,#type: ignore
-            total_tokens=tokens.total_tokens,
             partition_idx=source_samples.partition_idx,
             padding_mask=None if source_samples.padding_mask is None else 0,#type: ignore
             functional_inputs=None if source_samples.functional_inputs is None else 0,#type: ignore

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -21,14 +21,20 @@ def cudnn_attention(
 ) -> Array:
     """Flash attention via cuDNN backend.
 
-    Thin wrapper around jax.nn.dot_product_attention that forces
-    the cuDNN implementation and discards Flax-specific kwargs
-    (dropout_rng, dropout_rate, etc.).
+    Accepts either a 1-D integer array of shape (batch,) as seq lengths
+    (varlen path, no dense mask materialized)
+    Discards Flax-specific kwargs (dropout_rng, dropout_rate, etc.).
     """
     if mask is not None:
-        mask = mask.astype(jnp.bool_)
+        # Varlen flash attention: seq_lengths avoids any dense mask
+        return jax.nn.dot_product_attention(
+            query, key, value,
+            query_seq_lengths=mask,
+            key_value_seq_lengths=mask,
+            implementation="cudnn",
+        )
     return jax.nn.dot_product_attention(
-        query, key, value, mask=mask, implementation="cudnn"
+        query, key, value, implementation="cudnn"
     )
 
 class FFLayer(nnx.Module):

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -126,11 +126,13 @@ class Transformer(nnx.Module):
 
         # Apply encoder blocks sequentially via scan
         if tokens.padding_mask is not None:
-            sample_shape = tokens.sample_shape
-            n_tokens = tokens.data.shape[tokens.sample_ndims]
-            n_heads = self.config.n_heads
-            mask = tokens.padding_mask[:, None, None, :]
-            mask = jnp.broadcast_to(mask, sample_shape + (n_heads, n_tokens, n_tokens))
+            if self.config.attention == 'cudnn':
+                # Pass (batch,) seq lengths — varlen flash attention, no dense mask
+                mask = jnp.sum(tokens.padding_mask, axis=-1).astype(jnp.int32)
+            else:
+                # Compact key-padding mask (B, 1, 1, L); XLA broadcasts internally
+                mask = tokens.padding_mask[:, None, None, :]
+
         else:
             mask = None
 

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -127,8 +127,8 @@ class Transformer(nnx.Module):
         # Apply encoder blocks sequentially via scan
         if tokens.padding_mask is not None:
             if self.config.attention == 'cudnn':
-                # Pass (batch,) seq lengths — varlen flash attention, no dense mask
-                mask = jnp.sum(tokens.padding_mask, axis=-1).astype(jnp.int32)
+                # Pass (batch,) total_tokens — varlen flash attention, no dense mask
+                mask = jnp.full(tokens.padding_mask.shape[0], tokens.total_tokens, dtype=jnp.int32)
             else:
                 # Compact key-padding mask (B, 1, 1, L); XLA broadcasts internally
                 mask = tokens.padding_mask[:, None, None, :]

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -124,17 +124,7 @@ class Transformer(nnx.Module):
         # Embed tokens
         x = self.embedding(tokens, time)
 
-        # Apply encoder blocks sequentially via scan
-        if tokens.padding_mask is not None:
-            if self.config.attention == 'cudnn':
-                # Pass (batch,) total_tokens — varlen flash attention, no dense mask
-                mask = jnp.full(tokens.padding_mask.shape[0], tokens.total_tokens, dtype=jnp.int32)
-            else:
-                # Compact key-padding mask (B, 1, 1, L); XLA broadcasts internally
-                mask = tokens.padding_mask[:, None, None, :]
-
-        else:
-            mask = None
+        mask = tokens.attention_mask(self.config.attention)
 
         # Apply encoder blocks sequentially via scan
         @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)

--- a/tfmpe/preprocessing/tokens.py
+++ b/tfmpe/preprocessing/tokens.py
@@ -64,6 +64,7 @@ class Tokens:
     padding_mask: Optional[Array]
     functional_inputs: Optional[Array]
     group_id: Array
+    total_tokens: int
 
     @property
     def sample_ndims(self) -> int:
@@ -341,7 +342,8 @@ class Tokens:
             padding_mask=padding_mask,
             functional_inputs=func_inputs_flat,
             group_id=group_id,
-            partition_idx=partition_idx
+            partition_idx=partition_idx,
+            total_tokens=total_tokens
         )
 
         # Capture original token count for decoder to strip padding
@@ -386,7 +388,7 @@ class Tokens:
             self.functional_inputs,
             self.group_id,
         )
-        aux_data = {"partition_idx": self.partition_idx}
+        aux_data = {"partition_idx": self.partition_idx, "total_tokens": self.total_tokens}
         return (children, aux_data)
 
     @classmethod
@@ -427,5 +429,6 @@ class Tokens:
             padding_mask=padding_mask,
             functional_inputs=functional_inputs,
             group_id=group_id,
-            partition_idx=aux_data["partition_idx"]
+            partition_idx=aux_data["partition_idx"],
+            total_tokens=aux_data["total_tokens"]
         )

--- a/tfmpe/preprocessing/tokens.py
+++ b/tfmpe/preprocessing/tokens.py
@@ -64,7 +64,6 @@ class Tokens:
     padding_mask: Optional[Array]
     functional_inputs: Optional[Array]
     group_id: Array
-    total_tokens: int
 
     @property
     def sample_ndims(self) -> int:
@@ -89,6 +88,31 @@ class Tokens:
             Shape of sample dimensions
         """
         return self.data.shape[:self.sample_ndims]
+
+    def attention_mask(self, attention: str) -> Optional[Array]:
+        """Build attention mask in backend-specific format.
+
+        Parameters
+        ----------
+        attention : str
+            Attention backend name (e.g. ``softmax``, ``linear``,
+            ``cudnn``).
+
+        Returns
+        -------
+        Optional[Array]
+            Mask in the expected format for the selected attention
+            backend, or ``None`` if no padding mask is present.
+        """
+        if self.padding_mask is None:
+            return None
+
+        if attention == "cudnn":
+            # Varlen flash attention expects per-sample sequence lengths.
+            return jnp.sum(self.padding_mask, axis=-1).astype(jnp.int32)
+
+        # Dense key-padding mask broadcastable to attention logits.
+        return self.padding_mask[..., None, None, :]
 
     @classmethod
     def from_pytree(
@@ -343,7 +367,6 @@ class Tokens:
             functional_inputs=func_inputs_flat,
             group_id=group_id,
             partition_idx=partition_idx,
-            total_tokens=total_tokens
         )
 
         # Capture original token count for decoder to strip padding
@@ -388,7 +411,7 @@ class Tokens:
             self.functional_inputs,
             self.group_id,
         )
-        aux_data = {"partition_idx": self.partition_idx, "total_tokens": self.total_tokens}
+        aux_data = {"partition_idx": self.partition_idx}
         return (children, aux_data)
 
     @classmethod
@@ -430,5 +453,4 @@ class Tokens:
             functional_inputs=functional_inputs,
             group_id=group_id,
             partition_idx=aux_data["partition_idx"],
-            total_tokens=aux_data["total_tokens"]
         )


### PR DESCRIPTION
## Summary
This PR makes an update to the masking strategy for the cudanns flash attention. This is to avoid OOMs for large number of sites.

## Changes
### New Features
- A dense mask is no longer created. Instead a 1D array of (batch,) is passed into query_seq_lengths, key_seq_lengths

### Breaking Changes

### Fixes

---

## Reviewer Checklist

### All PRs
- [ ] **Correctness**: Logic is sound and implementation is correct
- [ ] **Testing**: Appropriate tests added/updated
- [ ] **Benchmarking**: Training/sampling speed impact assessed if relevant
- [ ] **Documentation**: Code comments and docs updated where needed

### For AI-Generated PRs
- [ ] **Entropy**: No unnecessary code duplication, verbose implementations,
      or misplaced imports
- [ ] **Test Quality**: Tests genuinely validate intended behavior (check
      `.claude/spec/{feature}/tasks.md` for requirements)
- [ ] **Steering Docs**: Fundamental changes to the repo (if any) are
        reflected in steering documents `.claude/steering/`
